### PR TITLE
Use `docker` image.

### DIFF
--- a/ansible/roles/swarmdroplet/defaults/main.yml
+++ b/ansible/roles/swarmdroplet/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-swarm_droplet_image: fb9c68 # Docker 17.04.0-ce on 16.04
+swarm_droplet_image: docker
 swarm_droplet_size: 1gb
 swarm_private_networking: yes
 swarm_region: fra1


### PR DESCRIPTION
Using this stops the need for always updating the image id